### PR TITLE
fix: Remove unused proto imports.

### DIFF
--- a/src/main/proto/service/appoinment.proto
+++ b/src/main/proto/service/appoinment.proto
@@ -4,9 +4,6 @@ option java_package = "org.spin.proto.mobile.appoinment";
 option java_multiple_files = true;
 
 import "google/api/annotations.proto";
-import "google/protobuf/empty.proto";
-import "google/protobuf/timestamp.proto";
-import "google/protobuf/struct.proto";
 
 package appoinment;
 

--- a/src/main/proto/service/auth.proto
+++ b/src/main/proto/service/auth.proto
@@ -4,9 +4,6 @@ option java_package = "org.spin.proto.mobile.auth";
 option java_multiple_files = true;
 
 import "google/api/annotations.proto";
-import "google/protobuf/empty.proto";
-import "google/protobuf/timestamp.proto";
-import "google/protobuf/struct.proto";
 
 package auth;
 

--- a/src/main/proto/service/settings.proto
+++ b/src/main/proto/service/settings.proto
@@ -4,9 +4,6 @@ option java_package = "org.spin.proto.mobile.settings";
 option java_multiple_files = true;
 
 import "google/api/annotations.proto";
-import "google/protobuf/empty.proto";
-import "google/protobuf/timestamp.proto";
-import "google/protobuf/struct.proto";
 
 package settings;
 


### PR DESCRIPTION

```log
Execution failed for task ':generateProto'.
> protoc: stdout: . stderr: service/appoinment.proto:8:1: warning: Import google/protobuf/timestamp.proto is unused.
  service/appoinment.proto:9:1: warning: Import google/protobuf/struct.proto is unused.
  service/appoinment.proto:7:1: warning: Import google/protobuf/empty.proto is unused.
  service/auth.proto:8:1: warning: Import google/protobuf/timestamp.proto is unused.
  service/auth.proto:9:1: warning: Import google/protobuf/struct.proto is unused.
  service/auth.proto:7:1: warning: Import google/protobuf/empty.proto is unused.
  service/settings.proto:8:1: warning: Import google/protobuf/timestamp.proto is unused.
  service/settings.proto:9:1: warning: Import google/protobuf/struct.proto is unused.
  service/settings.proto:7:1: warning: Import google/protobuf/empty.proto is unused.
```